### PR TITLE
updated qft.ipynb

### DIFF
--- a/content/ch-algorithms/quantum-fourier-transform.ipynb
+++ b/content/ch-algorithms/quantum-fourier-transform.ipynb
@@ -431,7 +431,7 @@
     "\\left[\n",
     "\\vert0\\rangle + \n",
     "\\exp\\left(\n",
-    "\\frac{2\\pi i}{2^1}x_3 + \\frac{2\\pi i}{2^2}x_2 + \\frac{2\\pi i}{2}x_1\n",
+    "\\frac{2\\pi i}{2^3}x_3 + \\frac{2\\pi i}{2^2}x_2 + \\frac{2\\pi i}{2}x_1\n",
     "\\right) \n",
     "\\vert1\\rangle\\right]\n",
     "$$\n",
@@ -454,7 +454,7 @@
     "\\left[\n",
     "\\vert0\\rangle + \n",
     "\\exp\\left(\n",
-    "\\frac{2\\pi i}{2^1}x_3 + \\frac{2\\pi i}{2^2}x_2 + \\frac{2\\pi i}{2}x_1\n",
+    "\\frac{2\\pi i}{2^3}x_3 + \\frac{2\\pi i}{2^2}x_2 + \\frac{2\\pi i}{2}x_1\n",
     "\\right) \n",
     "\\vert1\\rangle\\right]\n",
     "$$\n",
@@ -483,7 +483,7 @@
     "\\left[\n",
     "\\vert0\\rangle + \n",
     "\\exp\\left(\n",
-    "\\frac{2\\pi i}{2^1}x_3 + \\frac{2\\pi i}{2^2}x_2 + \\frac{2\\pi i}{2}x_1\n",
+    "\\frac{2\\pi i}{2^3}x_3 + \\frac{2\\pi i}{2^2}x_2 + \\frac{2\\pi i}{2}x_1\n",
     "\\right) \n",
     "\\vert1\\rangle\\right]\n",
     "$$\n",
@@ -4437,7 +4437,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let’s now encode the a number in the computational basis. We can see the number 5 in binary is `101`:"
+    "Let’s now encode a number in the computational basis. We can see the number 5 in binary is `101`:"
    ]
   },
   {
@@ -42041,7 +42041,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description of Issue (if Applicable)

1. Let’s now encode the a number in the computational basis. We can see the number 5 in binary is 101"
2. Ch 3.6 Section 6 Steps 3,4,5 Effect of CROT1 gate to |x1> depending on |x3> = (exp(2πi/2^3)x3)|1>

Fixes #your_issue_number_here

## What Changes Were Made?

## How Was This Tested?

Please provide any screenshots if applicable.

## Anything Else We Should Know 
